### PR TITLE
Support for M1 Silicon on Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,11 @@
                             <ws>cocoa</ws>
                             <arch>x86_64</arch>
                         </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>aarch64</arch>
+                        </environment>
                     </environments>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Added Arm 64 target for Mac OS X to support M1 silicon.

Original PR in LF repo (https://github.com/lf-lang/lingua-franca/pull/1530) by @hokeun