### PR TITLE
Move bump_version script over from main lingua-franca repo

### DIFF
--- a/util/bump-versions
+++ b/util/bump-versions
@@ -1,0 +1,179 @@
+#! /bin/python3
+
+import os
+from os.path import join, dirname, abspath
+
+# Usage: see below. 
+# 
+# @author Steven Wong <housengw@berkeley.edu>
+def usage(): 
+    return  '''bump-versions [-h] [-p PROP] [-t TARGET] [-a]
+
+            update the version number in config.properties. 
+            Then, run `bump-versions --all` to update for all targets (maven and manifest files).
+
+            You can also specify a specific target and a specific property to update using `-t` and/or `-p`
+            ex. bump-versions -p xtextVersion -t maven
+            '''
+
+
+findPrintStyle = '%p:\\n'
+replace = '\\n'
+to = ' >>> '
+parentDir = dirname(dirname(abspath(__file__)))
+manifestFind = parentDir
+mavenFind = join(parentDir, 'pom.xml')
+excluded = ['target', 'build']
+
+class colors: 
+    RED = '\033[31m'
+    ENDC = '\033[m'
+    GREEN = '\033[32m'
+    YELLOW = '\033[33m'
+    BLUE = '\033[34m'
+    PURPLE = '\033[35m'
+
+def main(args):
+    import configparser
+    config = configparser.RawConfigParser()
+    config.optionxform = str
+    config.read(join(parentDir, 'gradle.properties'))
+    props =  dict(config.items('versions')).keys()
+
+    if args["prop"]:
+        prop = args["prop"]
+        if prop not in props:
+            print(colors.RED + "ERROR" + colors.ENDC + f": property {prop} does not exist")
+            return
+        props = [prop]
+
+    if args["all"] and args["target"]:
+        print(colors.RED + "ERROR" + colors.ENDC + f": --all and --target are mutually exclusive")
+        return
+
+    targetLower = args["target"].lower() if args["target"] else ""
+    quiet = args["quiet"]
+
+    if args["all"]:
+        updateManifestPackages(config, props, quiet)
+        updateMavenPackages(config, props, quiet)
+    elif targetLower == "maven":
+        updateMavenPackages(config, props, quiet)
+    elif targetLower == "manifest":
+        updateManifestPackages(config, props, quiet)
+    
+def getInput():
+    return input(colors.PURPLE + "The changes are printed to the screen. Enter [Y/y] to accept, [N/n] to reject, [Q/q] to skip: " + colors.ENDC).lower()
+
+def updateMavenPackages(config, props, quiet):
+    print(colors.GREEN + "Updating versions for >>> ./pom.xml" + colors.ENDC)
+    propertyNameToVersion = dict(config.items('versions'))
+    for prop in props:
+        print("[MAVEN] Updating version for variable: " + colors.GREEN + prop + colors.ENDC)
+        os.system(generateMavenViewCommand(prop, propertyNameToVersion[prop]))
+        c = ''
+        while c != 'y' and c != 'n':
+            c = 'y' if quiet else getInput()
+            print()
+            if c == 'y':
+                os.system(generateMavenReplaceCommand(prop, propertyNameToVersion[prop]))
+            elif c == 'q':
+                return
+
+
+def updateManifestPackages(config, props, quiet):
+    print(colors.GREEN + "Updating versions for >>> manifest files" + colors.ENDC)
+    packageToPropertyName = dict(config.items('manifestPropertyNames'))
+    propertyNameToVersion = dict(config.items('versions'))
+
+    for prop in props:
+        manifestPackages = [package for package, propertyName in packageToPropertyName.items() if prop == propertyName]
+
+        if len(manifestPackages) == 0 or prop not in propertyNameToVersion:
+            print(colors.YELLOW + "WARNING" + colors.ENDC + f": Property '{prop}' does not exist for Manifest files.\n")
+        
+        for package in manifestPackages:
+            print("[MANIFEST] Updating version for package: " + colors.GREEN + package + colors.ENDC)
+            os.system(generateManifestViewCommand(package, propertyNameToVersion[prop]))
+            c = ''
+            while c != 'y' and c != 'n':
+                c = 'y' if quiet else getInput()
+                print()
+                if c == 'y':
+                    os.system(generateManifestReplaceCommand(package, propertyNameToVersion[prop]))
+                elif c == 'q':
+                    return
+
+
+def excludeFromFind():
+    return ' '.join(f'! -path \"**/{it}/**\"' for it in excluded)
+
+
+def generateManifestViewCommand(matchName, version):
+    return f'''
+    find {manifestFind} -name *.MF {excludeFromFind()} -type f -printf '{findPrintStyle}' -exec sed -n '/{matchName}.*;bundle-version/{{
+    h
+    s/="[^"][^"]*"/="{version}"/g
+    H
+    x
+    s/{replace}/{to}/
+    w /dev/fd/2
+    x
+    }}' {{}} \;
+    '''
+
+
+def generateManifestReplaceCommand(matchName, version):
+    return f'''
+    find {manifestFind} -name *.MF {excludeFromFind()} -type f -exec sed -i '/{matchName}.*;bundle-version/{{
+    h
+    s/="[^"][^"]*"/="{version}"/g
+    }}' {{}} \;
+    '''
+
+def generateMavenViewCommand(matchName, version):
+    return f'''
+    find {mavenFind} -printf '{findPrintStyle}' -exec sed -n '/<{matchName}>.*<\/{matchName}>/{{
+    h
+    s/<{matchName}>.*<\/{matchName}>/<{matchName}>{version}<\/{matchName}>/g
+    H
+    x
+    s/{replace}/{to}/
+    w /dev/fd/2
+    x
+    }}' {{}} \;
+    '''
+
+
+def generateMavenReplaceCommand(matchName, version):
+    return f'''
+    find {mavenFind} -exec sed -i '/<{matchName}>.*<\/{matchName}>/{{
+    h
+    s/<{matchName}>.*<\/{matchName}>/<{matchName}>{version}<\/{matchName}>/g
+    }}' {{}} \;
+    '''
+
+if __name__ == '__main__':
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(usage=usage())
+    targetGroup = parser.add_mutually_exclusive_group(required=True)
+
+    # Adding optional argument
+    parser.add_argument("-p", "--prop", help="version property to update")
+    parser.add_argument("-q", "--quiet", help="default accept all of the version changes", action="store_true")
+    targetGroup.add_argument("-t", "--target", help="target build application to update. Can be one of 'maven' or 'manifest' (case insensitive)")
+    targetGroup.add_argument("-a", "--all", help="update dependencies for all targets (maven and manifest files)", action="store_true")
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        parser.exit()
+
+    # Read arguments from command line
+    args = vars(parser.parse_args())
+
+    if 'all' not in args and 'target' not in args:
+        parser.print_help()
+
+    main(args)

--- a/util/bump-versions
+++ b/util/bump-versions
@@ -37,9 +37,8 @@ def main(args):
     import configparser
     config = configparser.RawConfigParser()
     config.optionxform = str
-    config.read(join(parentDir, 'gradle.properties'))
+    config.read(join(parentDir, 'org.lflang/lingua-franca/gradle.properties'))
     props =  dict(config.items('versions')).keys()
-
     if args["prop"]:
         prop = args["prop"]
         if prop not in props:


### PR DESCRIPTION
This adds the bump_version script (unchanged) from the main repo. Since it is used to synchronize dependency versions between the gradle and maven setups, it is better located here. In this repo we have access to both the gradle configuration in the submodule and the Maven configuration.

The script needs to be updated as many paths have changed. Also we need to be aware that some versions are now located also in `buildSrc/gradle.properties` in the main repo.