### PR TITLE
[CI] Updated configuration for Eclipse tests

### DIFF
--- a/.github/workflows/eclipse-tests.yml
+++ b/.github/workflows/eclipse-tests.yml
@@ -15,17 +15,18 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Prepare build environment
-        uses: lf-lang/lingua-franca/.github/actions/prepare-build-env@master
-      - name: Check Maven/Java configuration
-        run: mvn -version
+      - name: Set up Java 17 and check Mavan/Java configuration
+        run: |
+          echo "$JAVA_HOME_17_X64/bin" >> $GITHUB_PATH
+          echo "JAVA_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+          echo $(which java)
+          echo $JAVA_HOME
+          mvn -version
         shell: bash
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - name: Install pnpm
-        run: npm i -g pnpm
       - name: Run Eclipse tests
         run: mvn -U -P test integration-test
         shell: bash

--- a/.github/workflows/eclipse-tests.yml
+++ b/.github/workflows/eclipse-tests.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           node-version: 18
       - name: Run Eclipse tests
-        run: mvn -U -P test integration-test
+        run: mvn -B -U -P test integration-test
         shell: bash


### PR DESCRIPTION
No longer use action that depends on the presence of `gradlew`, which this repo no longer has.